### PR TITLE
Use multiple service-language combinations on the speech keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Point to the SDK directory by setting the environment variable
 
 Then run
 
-	gradle build
-	gradle lint
-	gradle installRelease
-	gradle ...
+    gradle makeIcons
+    gradle build
+    gradle lint
+    gradle assembleRelease
 
 For the listing of more Gradle tasks, run:
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -119,7 +119,7 @@
             android:theme="@style/Theme.K6nele.Dialog"></activity>
         <activity
             android:name=".ComboSelectorActivity"
-            android:label="@string/dialogTitleImeRecognitionServiceLanguage"
+            android:label="@string/dialogTitleCombo"
             android:parentActivityName=".Preferences"></activity>
         <activity
             android:name=".AppListActivity"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -118,6 +118,10 @@
             android:label="@string/labelActivityDetails"
             android:theme="@style/Theme.K6nele.Dialog"></activity>
         <activity
+            android:name=".ComboSelectorActivity"
+            android:label="@string/dialogTitleImeRecognitionServiceLanguage"
+            android:parentActivityName=".Preferences"></activity>
+        <activity
             android:name=".AppListActivity"
             android:label="@string/labelActivityAppList"
             android:parentActivityName=".Preferences"></activity>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId 'ee.ioc.phon.android.speak'
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1110
-        versionName '1.1.10'
+        versionCode 1111
+        versionName '1.1.11'
     }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId 'ee.ioc.phon.android.speak'
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1109
-        versionName '1.1.09'
+        versionCode 1110
+        versionName '1.1.10'
     }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId 'ee.ioc.phon.android.speak'
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1108
-        versionName '1.1.08'
+        versionCode 1109
+        versionName '1.1.09'
     }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId 'ee.ioc.phon.android.speak'
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1111
-        versionName '1.1.11'
+        versionCode 1112
+        versionName '1.1.12'
     }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId 'ee.ioc.phon.android.speak'
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1112
-        versionName '1.1.12'
+        versionCode 1200
+        versionName '1.2.00'
     }
 
 

--- a/app/res/drawable/button_combo.xml
+++ b/app/res/drawable/button_combo.xml
@@ -7,5 +7,4 @@
         </shape>
     </item>
     <item android:drawable="@android:color/transparent" />
-
 </selector>

--- a/app/res/drawable/button_combo.xml
+++ b/app/res/drawable/button_combo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/transparent_blue" />
+        </shape>
+    </item>
+    <item android:drawable="@android:color/transparent" />
+
+</selector>

--- a/app/res/layout-land/voice_ime_view.xml
+++ b/app/res/layout-land/voice_ime_view.xml
@@ -64,6 +64,17 @@
             android:textColor="@color/grey200"
             android:textSize="@dimen/textSize3" />
 
+        <TextView
+            android:id="@+id/tvServiceLanguage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@+id/bImeStartStop"
+            android:layout_toLeftOf="@+id/bImeStartStop"
+            android:padding="@dimen/layoutMargin1"
+            android:text="[TODO]"
+            android:textColor="@color/grey200"
+            android:textSize="@dimen/textSize3" />
+
         <ee.ioc.phon.android.speak.MicButton
             android:id="@+id/bImeStartStop"
             android:layout_width="@dimen/layoutHeightButtonMicrophone"

--- a/app/res/layout-land/voice_ime_view.xml
+++ b/app/res/layout-land/voice_ime_view.xml
@@ -66,13 +66,18 @@
             android:textSize="@dimen/textSize3" />
 
         <Button
-            android:id="@+id/tvServiceLanguage"
+            android:id="@+id/tvComboSelector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/tvMessage"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
+            android:layout_margin="@dimen/layoutMargin1"
             android:background="@drawable/button_combo"
+            android:ellipsize="end"
+            android:minHeight="@dimen/layoutMargin3"
+            android:minWidth="@dimen/layoutMargin3"
+            android:singleLine="true"
             android:text="@string/testComboLabel"
             android:textColor="@color/grey200"
             android:textSize="@dimen/textSize10sp" />

--- a/app/res/layout-land/voice_ime_view.xml
+++ b/app/res/layout-land/voice_ime_view.xml
@@ -13,7 +13,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/layoutMargin0">
+        android:padding="@dimen/layoutMargin4dp">
 
         <ImageButton
             android:id="@+id/bImeKeyboard"
@@ -51,6 +51,7 @@
             android:ellipsize="start"
             android:padding="@dimen/layoutMargin1"
             android:singleLine="true"
+            android:text="@string/testComboLabel"
             android:textColor="@color/grey300"
             android:textSize="@dimen/textSize2" />
 
@@ -66,13 +67,17 @@
 
         <Button
             android:id="@+id/tvServiceLanguage"
+            style="?android:attr/buttonStyleSmall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/bImeStartStop"
-            android:layout_toLeftOf="@+id/bImeStartStop"
+            android:layout_below="@+id/tvMessage"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
             android:padding="@dimen/layoutMargin1"
-            android:text="[TODO]"
-            android:textSize="@dimen/textSize1" />
+            android:text="@string/testComboLabel"
+            android:textColor="@color/grey200"
+            android:textSize="@dimen/textSize10sp" />
 
         <ee.ioc.phon.android.speak.MicButton
             android:id="@+id/bImeStartStop"

--- a/app/res/layout-land/voice_ime_view.xml
+++ b/app/res/layout-land/voice_ime_view.xml
@@ -64,7 +64,7 @@
             android:textColor="@color/grey200"
             android:textSize="@dimen/textSize3" />
 
-        <TextView
+        <Button
             android:id="@+id/tvServiceLanguage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -72,8 +72,7 @@
             android:layout_toLeftOf="@+id/bImeStartStop"
             android:padding="@dimen/layoutMargin1"
             android:text="[TODO]"
-            android:textColor="@color/grey200"
-            android:textSize="@dimen/textSize3" />
+            android:textSize="@dimen/textSize1" />
 
         <ee.ioc.phon.android.speak.MicButton
             android:id="@+id/bImeStartStop"

--- a/app/res/layout-land/voice_ime_view.xml
+++ b/app/res/layout-land/voice_ime_view.xml
@@ -67,14 +67,12 @@
 
         <Button
             android:id="@+id/tvServiceLanguage"
-            style="?android:attr/buttonStyleSmall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/tvMessage"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:background="@android:color/transparent"
-            android:padding="@dimen/layoutMargin1"
+            android:background="@drawable/button_combo"
             android:text="@string/testComboLabel"
             android:textColor="@color/grey200"
             android:textSize="@dimen/textSize10sp" />

--- a/app/res/layout/list_item_combo.xml
+++ b/app/res/layout/list_item_combo.xml
@@ -8,6 +8,7 @@
         android:id="@+id/language"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/grey50"
         android:textSize="@dimen/textSize3" />
 
     <TextView
@@ -21,6 +22,8 @@
         android:id="@+id/check"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true" />
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true" />
 
 </RelativeLayout>

--- a/app/res/layout/list_item_combo.xml
+++ b/app/res/layout/list_item_combo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/layoutMargin1">
+
+    <TextView
+        android:id="@+id/language"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/textSize3" />
+
+    <TextView
+        android:id="@+id/service"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/language"
+        android:textSize="@dimen/textSize2" />
+
+    <CheckBox
+        android:id="@+id/check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true" />
+
+</RelativeLayout>

--- a/app/res/layout/voice_ime_view.xml
+++ b/app/res/layout/voice_ime_view.xml
@@ -79,17 +79,16 @@
         android:textColor="@color/grey200"
         android:textSize="@dimen/textSize3" />
 
-    <TextView
+    <Button
         android:id="@+id/tvServiceLanguage"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_margin="@dimen/layoutMargin1"
+        android:ellipsize="end"
         android:gravity="center"
         android:singleLine="true"
-        android:ellipsize="end"
         android:text="Estonian (Estonia) @ Kõnele (fast recognition)"
-        android:textColor="@color/grey200"
-        android:textSize="@dimen/textSize2" />
+        android:textSize="@dimen/textSize1" />
 
 </ee.ioc.phon.android.speak.VoiceImeView>

--- a/app/res/layout/voice_ime_view.xml
+++ b/app/res/layout/voice_ime_view.xml
@@ -32,7 +32,7 @@
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:layout_margin="@dimen/layoutMargin1"
+            android:layout_margin="@dimen/layoutMargin4dp"
             android:layout_toEndOf="@+id/bImeKeyboard"
             android:layout_toLeftOf="@+id/bImeGo"
             android:layout_toRightOf="@+id/bImeKeyboard"
@@ -40,6 +40,7 @@
             android:ellipsize="start"
             android:gravity="center"
             android:singleLine="true"
+            android:text="@string/testComboLabel"
             android:textColor="@color/grey300"
             android:textSize="@dimen/textSize2" />
 
@@ -61,8 +62,6 @@
         android:layout_width="@dimen/layoutHeightButtonMicrophone"
         android:layout_height="@dimen/layoutHeightButtonMicrophone"
         android:layout_gravity="center"
-        android:layout_marginBottom="@dimen/layoutMargin1"
-        android:layout_marginTop="@dimen/layoutMargin0"
         android:background="@drawable/button_mic"
         android:contentDescription="@string/cdMicrophone"
         android:gravity="center"
@@ -73,7 +72,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/layoutMargin1"
+        android:layout_margin="@dimen/layoutMargin4dp"
         android:gravity="center"
         android:text="@string/buttonImeSpeak"
         android:textColor="@color/grey200"
@@ -81,14 +80,17 @@
 
     <Button
         android:id="@+id/tvServiceLanguage"
+        style="?android:attr/buttonStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/layoutMargin1"
+        android:layout_margin="@dimen/layoutMargin4dp"
+        android:background="@android:color/transparent"
         android:ellipsize="end"
         android:gravity="center"
         android:singleLine="true"
-        android:text="Estonian (Estonia) @ Kõnele (fast recognition)"
-        android:textSize="@dimen/textSize1" />
+        android:text="@string/testComboLabel"
+        android:textColor="@color/grey200"
+        android:textSize="@dimen/textSize10sp" />
 
 </ee.ioc.phon.android.speak.VoiceImeView>

--- a/app/res/layout/voice_ime_view.xml
+++ b/app/res/layout/voice_ime_view.xml
@@ -80,12 +80,10 @@
 
     <Button
         android:id="@+id/tvServiceLanguage"
-        style="?android:attr/buttonStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/layoutMargin4dp"
-        android:background="@android:color/transparent"
+        android:background="@drawable/button_combo"
         android:ellipsize="end"
         android:gravity="center"
         android:singleLine="true"

--- a/app/res/layout/voice_ime_view.xml
+++ b/app/res/layout/voice_ime_view.xml
@@ -79,4 +79,17 @@
         android:textColor="@color/grey200"
         android:textSize="@dimen/textSize3" />
 
+    <TextView
+        android:id="@+id/tvServiceLanguage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/layoutMargin1"
+        android:gravity="center"
+        android:singleLine="true"
+        android:ellipsize="end"
+        android:text="Estonian (Estonia) @ Kõnele (fast recognition)"
+        android:textColor="@color/grey200"
+        android:textSize="@dimen/textSize2" />
+
 </ee.ioc.phon.android.speak.VoiceImeView>

--- a/app/res/layout/voice_ime_view.xml
+++ b/app/res/layout/voice_ime_view.xml
@@ -79,13 +79,16 @@
         android:textSize="@dimen/textSize3" />
 
     <Button
-        android:id="@+id/tvServiceLanguage"
+        android:id="@+id/tvComboSelector"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:layout_margin="@dimen/layoutMargin1"
         android:background="@drawable/button_combo"
         android:ellipsize="end"
         android:gravity="center"
+        android:minHeight="@dimen/layoutMargin3"
+        android:minWidth="@dimen/layoutMargin3"
         android:singleLine="true"
         android:text="@string/testComboLabel"
         android:textColor="@color/grey200"

--- a/app/res/values-et/strings.xml
+++ b/app/res/values-et/strings.xml
@@ -254,14 +254,13 @@
     <string name="titleDefaultServiceHttp">HTTP-aadress</string>
     <string name="titleDefaultServiceWs">WebSocket-aadress</string>
     <string name="labelRecognitionServiceHttpWithComment">Kõnele (grammatikatoega). Ainuvõimalik valik Kõnele praeguses versioonis.</string>
-    <string name="labelDefaultRecognitionService">Süsteemne vaikeväärtus</string>
     <string name="titleEnableIme">Kõneklaviatuuri sisse lülitamine</string>
-    <string name="summaryEnableIme">Kõnele klaviatuur pole praegu sisse lülitatud. Lülitage see Androidi sisestusmeetodite (IME) seadetes sisse.</string>
+    <string name="summaryEnableIme">Kõnele klaviatuur pole praegu sisse lülitatud. Vajutage siia nupule, et see Androidi sisestusmeetodite (IME) seadetes sisse lülitada.</string>
     <string name="summaryImeHelpText">Näita kõneklaviatuuril abiteksti (teeb klaviatuuri sellevõrra suuremaks)</string>
     <string name="titleImeHelpText">Abitekst</string>
-    <string name="noteRecognitionLanguageUndefined">(määramata)</string>
-    <string name="dialogTitleImeRecognitionServiceLanguage">Teenused &amp; keeled</string>
-    <string name="titleRecognitionServiceLanguage">Kõnetuvastusteenused ja keeled</string>
-    <string name="summaryImeRecognitionServiceLanguage">Uuendan…</string>
+    <string name="dialogTitleCombo">Keeled &amp; teenused</string>
+    <string name="titleCombo">Kõnetuvastuskeeled &amp; teenused</string>
+    <string name="summaryImeCombo">Uuendan…</string>
+    <string name="emptylistCombos">Praegu kasutatakse eesti keelt ja Kõnele (kiire tuvastusega) teenust. Keelte ja teenuste lisamiseks või muutmiseks vajutage nupule.</string>
 
 </resources>

--- a/app/res/values-et/strings.xml
+++ b/app/res/values-et/strings.xml
@@ -52,9 +52,6 @@
     <string name="summaryVoiceSearchDemo">Transkribeerib kõne ning edastab tulemused
 		infootsingu rakendusele</string>
 
-    <string name="titleRecognitionService">Kõnetuvastusteenus</string>
-    <string name="dialogTitleImeRecognitionService">Kõnetuvastusteenus</string>
-
     <!-- RecognizerIntent activity -->
     <string name="buttonSpeak">Lindista!</string>
     <string name="buttonStop">Lõpeta!</string>
@@ -262,8 +259,9 @@
     <string name="summaryEnableIme">Kõnele klaviatuur pole praegu sisse lülitatud. Lülitage see Androidi sisestusmeetodite (IME) seadetes sisse.</string>
     <string name="summaryImeHelpText">Näita kõneklaviatuuril abiteksti (teeb klaviatuuri sellevõrra suuremaks)</string>
     <string name="titleImeHelpText">Abitekst</string>
-    <string name="dialogTitleImeRecognitionLanguage">Tuvastuskeel</string>
-    <string name="titleRecognitionLanguage">Tuvastuskeel</string>
     <string name="noteRecognitionLanguageUndefined">(määramata)</string>
+    <string name="dialogTitleImeRecognitionServiceLanguage">Teenused &amp; keeled</string>
+    <string name="titleRecognitionServiceLanguage">Kõnetuvastusteenused ja keeled</string>
+    <string name="summaryImeRecognitionServiceLanguage">Uuendan…</string>
 
 </resources>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -30,7 +30,7 @@
 
 
     <!-- 1 = top,lighter; 2 = bottom,darker -->
-    <color name="transparent">#00000000</color>
+    <!-- <color name="transparent">#00000000</color> -->
     <color name="very_transparent">#11404040</color>
     <color name="transparent_blue">#990099cc</color>
     <color name="buttonNormal1">#ffcc00</color>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -6,9 +6,8 @@
     <dimen name="textSize3">18sp</dimen>
     <dimen name="textSize4">22sp</dimen>
     <dimen name="layoutHeightButtonMicrophone">80dp</dimen>
-    <dimen name="layoutMargin2dp">2dp</dimen>
     <dimen name="layoutMargin4dp">4dp</dimen>
     <dimen name="layoutMargin1">8dp</dimen>
     <dimen name="layoutMargin2">16dp</dimen>
-    <dimen name="layoutMargin0dp">0dp</dimen>
+    <dimen name="layoutMargin3">24dp</dimen>
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -6,7 +6,9 @@
     <dimen name="textSize3">18sp</dimen>
     <dimen name="textSize4">22sp</dimen>
     <dimen name="layoutHeightButtonMicrophone">80dp</dimen>
+    <dimen name="layoutMargin2dp">2dp</dimen>
     <dimen name="layoutMargin4dp">4dp</dimen>
     <dimen name="layoutMargin1">8dp</dimen>
     <dimen name="layoutMargin2">16dp</dimen>
+    <dimen name="layoutMargin0dp">0dp</dimen>
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="textSize10sp">10sp</dimen>
     <dimen name="textSize1">12sp</dimen>
     <dimen name="textSize2">14sp</dimen>
     <dimen name="textSize3">18sp</dimen>
     <dimen name="textSize4">22sp</dimen>
     <dimen name="layoutHeightButtonMicrophone">80dp</dimen>
-    <dimen name="layoutMargin0">2dp</dimen>
+    <dimen name="layoutMargin4dp">4dp</dimen>
     <dimen name="layoutMargin1">8dp</dimen>
     <dimen name="layoutMargin2">16dp</dimen>
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -15,8 +15,8 @@
     <string name="keyImeAutoStart" translatable="false">keyImeAutoStart</string>
     <string name="keyImeAudioCues" translatable="false">keyImeAudioCues</string>
     <string name="keyImeHelpText" translatable="false">keyImeHelpText</string>
-    <string name="keyImeRecognitionServiceLanguage" translatable="false">keyImeRecognitionServiceLanguage</string>
-    <string name="keyActivityRecognitionServiceLanguage" translatable="false">keyActivityRecognitionServiceLanguage</string>
+    <string name="keyImeCombo" translatable="false">keyImeCombo</string>
+    <string name="keyActivityCombo" translatable="false">keyActivityCombo</string>
     <string name="defaultServerHttp" translatable="false">http://bark.phon.ioc.ee/speech-api/v1/recognize</string>
     // These keys are needed to locate (to show/hide) the "enable ime" link in the settings
     <string name="keyEnableIme" translatable="false">keyEnableIme</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -38,8 +38,6 @@
     </string-array>
     <string-array name="empty" translatable="false"></string-array>
 
-    <string name="defaultRecognitionLanguage" translatable="false">et-EE</string>
-
     <string name="labelComboListItem" translatable="false">• %2$s @ %1$s</string>
 
     <string name="descriptionApp">speech-to-text services for Android apps</string>
@@ -62,7 +60,6 @@
     <string name="labelActivityExtrasDemo">Extras demo</string>
     <string name="labelActivityRepeaterDemo">Repeater demo</string>
     <string name="labelActivityVoiceSearchDemo">Voice search demo</string>
-    <string name="labelDefaultRecognitionService">System default</string>
 
     <!-- Preferences activity -->
     <string name="titleDefaultServiceHttp">HTTP URL</string>
@@ -92,17 +89,17 @@
     <string name="summaryAudioCues">Beep before and after recording</string>
     <string name="titleImeHelpText">Help text</string>
     <string name="summaryImeHelpText">Show help text by the microphone button (makes the speech keyboard larger)</string>
-    <string name="summaryImeRecognitionServiceLanguage">Updating…</string>
+    <string name="summaryImeCombo">Updating…</string>
     <string name="titleEnableIme">Enable speech keyboard</string>
-    <string name="summaryEnableIme">The Kõnele speech keyboard is currently disabled. Enable it in the Android input method (IME) settings.</string>
+    <string name="summaryEnableIme">The Kõnele speech keyboard is currently disabled. Tap here to enable it in the Android input method (IME) settings.</string>
     <string name="summaryAppList">List of apps where you have used speech input</string>
     <string name="summaryGrammarList">List of grammars that translate the raw transcription into app-specific language</string>
     <string name="summarySimpleDemo">Demonstrates the simplest way of using the speech recognizer</string>
     <string name="summaryExtrasDemo">Shows only the "result extras" returned by the recognizer</string>
     <string name="summaryRepeaterDemo">Repeatedly calls the speech recognizer and shows the best transcription. Grammar can be assigned to the input (via menu).</string>
     <string name="summaryVoiceSearchDemo">Forwards the results to a search app</string>
-    <string name="titleRecognitionServiceLanguage">Recognition services &amp; languages</string>
-    <string name="dialogTitleImeRecognitionServiceLanguage">Services &amp; languages</string>
+    <string name="titleCombo">Recognition languages &amp; services</string>
+    <string name="dialogTitleCombo">Languages &amp; services</string>
 
     <!-- RecognizerIntent activity -->
     <string name="buttonSpeak">Tap &amp; Speak</string>
@@ -119,45 +116,39 @@
     <!-- @string/descriptionApp -->
     <string name="tvAboutHeader">&lt;b>%1$s&lt;/b>: %2$s&lt;br />
 		v%3$s by &lt;a href="https://plus.google.com/+KaarelKaljurand">Kaarel Kaljurand&lt;/a></string>
-    <string name="tvAbout">&lt;p>%1$s
-is an app that offers speech-to-text services to other apps.
-Apps that allow user input via speech usually have a little microphone
-button as part of their user interface. Examples include:&lt;/p>
+    <string name="tvAbout">&lt;p>%1$s is an app that offers speech-to-text services to other apps.
+        Many apps contain a text area or a text field (e.g. a search bar) that can be edited using the keyboard.
+        %1$s provides a &lt;b>speech keyboard&lt;/b>, a one-button keyboard, which allows speech to be converted to text.
+        Many apps (e.g. intelligent assistants, keyboard apps, navigation apps) also contain a microphone button
+        that is linked to the &lt;b>standard Android voice search activity&lt;/b>.
+        %1$s provides an implementation of this activity.&lt;/p>
 
-&amp;nbsp;&amp;nbsp;&amp;bull; note taking and TODO-list apps;&lt;br/>
-&amp;nbsp;&amp;nbsp;&amp;bull; SMS apps;&lt;br/>
-&amp;nbsp;&amp;nbsp;&amp;bull; dictionary and translation tools;&lt;br/>
-&amp;nbsp;&amp;nbsp;&amp;bull; calculators (e.g. WolframAlpha);&lt;br/>
-&amp;nbsp;&amp;nbsp;&amp;bull; apps that include the standard search bar (e.g. GMail, Google Drive, YouTube).
+&lt;p>In the background, %1$s uses two speech recognition servers.
+        One supports &lt;b>grammar-based speech recognition&lt;/b>, the other supports &lt;b>continuous full-duplex speech recognition&lt;/b>.
+        Both servers focus on &lt;b>Estonian speech recognition&lt;/b>, but both are based on a fully open-source stack that makes them easy to deploy
+        and customize for other languages.
+        For more information, see &lt;a href="http://phon.ioc.ee">http://phon.ioc.ee&lt;/a>.&lt;/p>
 
-		&lt;p>%1$s is
-		pre-configured to
-		use online Estonian speech-to-text services
-		(see &lt;a
-		href="http://phon.ioc.ee">http://phon.ioc.ee&lt;/a>)
-		but
-		you can reconfigure it to use any online speech-to-text server
-		provided
-		that it implements the same interface.&lt;/p>
+        &lt;p>How to use the speech keyboard? Tap the big yellow button and start dictating, the words
+        appear immediately in the text area.
+        Swipe left to delete the previous word, swipe right to add a newline, double-tap to add space.
+        Note that any recognition language and service available on the device can be used on the speech
+        keyboard. However, only the two services of %1$s have been tested.&lt;/p>
 
-&lt;p>%1$s supports grammar-based speech recognition, i.e. you can assign grammars to individual apps in order to
+&lt;p>How to use grammar-based speech recognition? Use the \"Apps &amp; Grammars\" settings to assign grammars to individual apps in order to
 improve the recognition quality and map the recognized speech automatically to the expected application format.
 %1$s is preloaded with links to several speech grammars for Estonian
 and English, covering domains like unit conversion, address queries, setting the alarm clock.
 More grammars are available at
 &lt;a href="http://kaljurand.github.io/Grammars/">http://kaljurand.github.io/Grammars/&lt;/a>.&lt;/p>
 
-&lt;p>%1$s can also be used as a (one-button) keyboard: tap the big yellow button and start dictating, the words
-        appear immediately in the text area.
-        Swipe left to delete the previous word, swipe right to add a newline, double-tap to add space.&lt;/p>
-
 		&lt;p>Documentation, source code, and the list of requested features and known issues are available at the
 		&lt;a href="http://kaljurand.github.io/K6nele/">%1$s website&lt;/a>.&lt;/p></string>
 
-    <!-- List view -->
     <string name="emptylistApps">No apps yet. This list will be automatically populated with the apps where you have used speech input.</string>
     <string name="emptylistGrammars">No grammars. Add a new grammar via the Add-menu.</string>
     <string name="emptylistServers">No servers. Add a new server via the Add-menu.</string>
+    <string name="emptylistCombos">Currently using Estonian and Kõnele (fast recognition). Tap here to add or change languages and services.</string>
     <string name="toastForwardedMatches">Recognized: %1$s</string>
     <string name="toastAssignGrammar">Assigned grammar: %1$s</string>
     <string name="toastRequestedAudioFormatNotSupported">Requested audio format not supported: %1$s</string>
@@ -191,7 +182,6 @@ More grammars are available at
     <string name="errorFailedGetGrammarUrl">ERROR: Failed to obtain the grammar URL</string>
     <string name="errorFailedGetServerUrl">ERROR: Failed to obtain the server URL</string>
     <string name="noteMaxRecordingTimeExceeded">Max recording time exceeded</string>
-    <string name="noteRecognitionLanguageUndefined">(undefined)</string>
     <string name="confirmDeleteEntry">Are you sure you want to delete entry \"%1$s\"?</string>
     <string name="confirmRemoveGrammar">Are you sure you do not want to set/override this app\'s grammar?</string>
     <string name="confirmRemoveServer">Are you sure you want to use the default server in this app?</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="summaryAudioCues">Beep before and after recording</string>
     <string name="titleImeHelpText">Help text</string>
     <string name="summaryImeHelpText">Show help text by the microphone button (makes the speech keyboard larger)</string>
+    <string name="summaryImeRecognitionServiceLanguage">Updating…</string>
     <string name="titleEnableIme">Enable speech keyboard</string>
     <string name="summaryEnableIme">The Kõnele speech keyboard is currently disabled. Enable it in the Android input method (IME) settings.</string>
     <string name="summaryAppList">List of apps where you have used speech input</string>
@@ -267,10 +268,8 @@ More grammars are available at
     </string-array>
 
     <string-array name="defaultImeRecognizerServiceLanguage" translatable="false">
-        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer</item>
         <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</item>
-        <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService</item>
-        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService</item>
+        <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService;en-us</item>
         <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;et-ee</item>
         <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;en-us</item>
     </string-array>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="labelApp" translatable="false">Kõnele</string>
     <string name="prefCurrentSortOrder" translatable="false">CurrentSortOrder</string>
+    <string name="keyCurrentCombo" translatable="false">keyCurrentCombo</string>
     <string name="keyServerHttp" translatable="false">keyServerHttp</string>
     <string name="keyServerWs" translatable="false">keyServerWs</string>
     <string name="keyRecordingRate" translatable="false">keyRecordingRate</string>
@@ -17,9 +18,6 @@
     <string name="keyImeRecognitionServiceLanguage" translatable="false">keyImeRecognitionServiceLanguage</string>
     <string name="keyActivityRecognitionServiceLanguage" translatable="false">keyActivityRecognitionServiceLanguage</string>
     <string name="defaultServerHttp" translatable="false">http://bark.phon.ioc.ee/speech-api/v1/recognize</string>
-    <string name="defaultImeRecognizerService" translatable="false">ee.ioc.phon.android.speak/.WebSocketRecognizer</string>
-    <string name="defaultImeRecognizerServiceLanguage" translatable="false">ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</string>
-    <string name="defaultActivityRecognizerService" translatable="false">ee.ioc.phon.android.speak/.SpeechRecognitionService</string>
     // These keys are needed to locate (to show/hide) the "enable ime" link in the settings
     <string name="keyEnableIme" translatable="false">keyEnableIme</string>
     <string name="keyCategoryIme" translatable="false">keyCategoryIme</string>
@@ -30,6 +28,7 @@
 
     <string name="defaultAutoStopAfterTime" translatable="false">20</string>
 
+    <!-- TODO: convert to integer-array -->
     <string-array name="valuesAutoStopAfterTime" translatable="false">
         <item>2</item>
         <item>5</item>
@@ -254,12 +253,11 @@ More grammars are available at
         <item>44 kHz</item>
     </string-array>
 
+    <!-- TODO: convert to integer -->
     <string name="defaultRecordingRate" translatable="false">16000</string>
 
-    <!-- Unfortunately cannot use an integer array -->
-    <!-- TODO: there is integer array now -->
+    <!-- TODO: convert to integer-array -->
     <string-array name="valuesRecordingRate" translatable="false">
-
         <!-- <item>8000</item> -->
         <item>11025</item>
         <item>16000</item>
@@ -269,9 +267,11 @@ More grammars are available at
 
     <string-array name="defaultImeRecognizerServiceLanguage" translatable="false">
         <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</item>
+        <!--
         <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService;en-us</item>
         <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;et-ee</item>
         <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;en-us</item>
+        -->
     </string-array>
 
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -14,11 +14,11 @@
     <string name="keyImeAutoStart" translatable="false">keyImeAutoStart</string>
     <string name="keyImeAudioCues" translatable="false">keyImeAudioCues</string>
     <string name="keyImeHelpText" translatable="false">keyImeHelpText</string>
-    <string name="keyImeRecognitionService" translatable="false">keyImeRecognitionService</string>
-    <string name="keyImeRecognitionLanguage" translatable="false">keyImeRecognitionLanguage</string>
-    <string name="keyActivityRecognitionService" translatable="false">keyActivityRecognitionService</string>
+    <string name="keyImeRecognitionServiceLanguage" translatable="false">keyImeRecognitionServiceLanguage</string>
+    <string name="keyActivityRecognitionServiceLanguage" translatable="false">keyActivityRecognitionServiceLanguage</string>
     <string name="defaultServerHttp" translatable="false">http://bark.phon.ioc.ee/speech-api/v1/recognize</string>
     <string name="defaultImeRecognizerService" translatable="false">ee.ioc.phon.android.speak/.WebSocketRecognizer</string>
+    <string name="defaultImeRecognizerServiceLanguage" translatable="false">ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</string>
     <string name="defaultActivityRecognizerService" translatable="false">ee.ioc.phon.android.speak/.SpeechRecognitionService</string>
     // These keys are needed to locate (to show/hide) the "enable ime" link in the settings
     <string name="keyEnableIme" translatable="false">keyEnableIme</string>
@@ -99,10 +99,8 @@
     <string name="summaryExtrasDemo">Shows only the "result extras" returned by the recognizer</string>
     <string name="summaryRepeaterDemo">Repeatedly calls the speech recognizer and shows the best transcription. Grammar can be assigned to the input (via menu).</string>
     <string name="summaryVoiceSearchDemo">Forwards the results to a search app</string>
-    <string name="titleRecognitionService">Recognition service</string>
-    <string name="titleRecognitionLanguage">Recognition language</string>
-    <string name="dialogTitleImeRecognitionService">Recognition service</string>
-    <string name="dialogTitleImeRecognitionLanguage">Recognition language</string>
+    <string name="titleRecognitionServiceLanguage">Recognition services &amp; languages</string>
+    <string name="dialogTitleImeRecognitionServiceLanguage">Services &amp; languages</string>
 
     <!-- RecognizerIntent activity -->
     <string name="buttonSpeak">Tap &amp; Speak</string>
@@ -258,6 +256,7 @@ More grammars are available at
     <string name="defaultRecordingRate" translatable="false">16000</string>
 
     <!-- Unfortunately cannot use an integer array -->
+    <!-- TODO: there is integer array now -->
     <string-array name="valuesRecordingRate" translatable="false">
 
         <!-- <item>8000</item> -->
@@ -265,6 +264,15 @@ More grammars are available at
         <item>16000</item>
         <item>22050</item>
         <item>44100</item>
+    </string-array>
+
+    <string-array name="defaultImeRecognizerServiceLanguage" translatable="false">
+        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer</item>
+        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</item>
+        <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService</item>
+        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService</item>
+        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;et-ee</item>
+        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;en-us</item>
     </string-array>
 
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -38,7 +38,9 @@
     </string-array>
     <string-array name="empty" translatable="false"></string-array>
 
-    <string name="defaultRecognitionLanguage" translatable="false">et-ee</string>
+    <string name="defaultRecognitionLanguage" translatable="false">et-EE</string>
+
+    <string name="labelComboListItem" translatable="false">• %2$s @ %1$s</string>
 
     <string name="descriptionApp">speech-to-text services for Android apps</string>
 
@@ -265,13 +267,22 @@ More grammars are available at
         <item>44100</item>
     </string-array>
 
-    <string-array name="defaultImeRecognizerServiceLanguage" translatable="false">
-        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee</item>
+    <string-array name="defaultImeCombos" translatable="false">
+        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;et-EE</item>
+    </string-array>
+
+    <!--
+    Set of recognizer service/language combos that we do not want to show for technical reasons.
+    This list can also contain service names to exclude the whole service with all its languages.
+    -->
+    <string-array name="defaultImeCombosExcluded" translatable="false">
+        <item>ee.ioc.phon.android.speak/.WebSocketRecognizer;en-US</item>
         <!--
-        <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService;en-us</item>
-        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;et-ee</item>
-        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService;en-us</item>
+        <item>com.google.android.googlequicksearchbox/com.google.android.voicesearch.serviceapi.GoogleRecognitionService</item>
+        <item>ee.ioc.phon.android.speak/.SpeechRecognitionService</item>
         -->
     </string-array>
 
+    <!-- Just for testing, won't appear in the product. -->
+    <string name="testComboLabel" translatable="false">English (United States) @ Kõnele (grammar support)</string>
 </resources>

--- a/app/res/xml/preferences.xml
+++ b/app/res/xml/preferences.xml
@@ -41,6 +41,7 @@
             android:entries="@array/empty"
             android:entryValues="@array/empty"
             android:key="@string/keyImeRecognitionServiceLanguage"
+            android:summary="@string/summaryImeRecognitionServiceLanguage"
             android:title="@string/titleRecognitionServiceLanguage" />
     </PreferenceCategory>
 

--- a/app/res/xml/preferences.xml
+++ b/app/res/xml/preferences.xml
@@ -36,18 +36,12 @@
             android:key="@string/keyImeHelpText"
             android:summary="@string/summaryImeHelpText"
             android:title="@string/titleImeHelpText" />
-        <ListPreference
-            android:dialogTitle="@string/dialogTitleImeRecognitionService"
+        <MultiSelectListPreference
+            android:dialogTitle="@string/dialogTitleImeRecognitionServiceLanguage"
             android:entries="@array/empty"
             android:entryValues="@array/empty"
-            android:key="@string/keyImeRecognitionService"
-            android:title="@string/titleRecognitionService" />
-        <ListPreference
-            android:dialogTitle="@string/dialogTitleImeRecognitionLanguage"
-            android:entries="@array/empty"
-            android:entryValues="@array/empty"
-            android:key="@string/keyImeRecognitionLanguage"
-            android:title="@string/titleRecognitionLanguage" />
+            android:key="@string/keyImeRecognitionServiceLanguage"
+            android:title="@string/titleRecognitionServiceLanguage" />
     </PreferenceCategory>
 
     // Voice search activity (TODO: unify terminology: dialog, panel, UI)
@@ -64,13 +58,13 @@
             android:title="@string/titleAudioCues" />
         // TODO: make the service of the main panel also user selectable
         <ListPreference
-            android:dialogTitle="@string/dialogTitleImeRecognitionLanguage"
+            android:dialogTitle="@string/dialogTitleImeRecognitionServiceLanguage"
             android:enabled="false"
             android:entries="@array/empty"
             android:entryValues="@array/empty"
-            android:key="@string/keyActivityRecognitionService"
+            android:key="@string/keyActivityRecognitionServiceLanguage"
             android:summary="@string/labelRecognitionServiceHttpWithComment"
-            android:title="@string/titleRecognitionService" />
+            android:title="@string/titleRecognitionServiceLanguage" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/titleCategoryApps">

--- a/app/res/xml/preferences.xml
+++ b/app/res/xml/preferences.xml
@@ -36,13 +36,14 @@
             android:key="@string/keyImeHelpText"
             android:summary="@string/summaryImeHelpText"
             android:title="@string/titleImeHelpText" />
-        <MultiSelectListPreference
-            android:dialogTitle="@string/dialogTitleImeRecognitionServiceLanguage"
-            android:entries="@array/empty"
-            android:entryValues="@array/empty"
-            android:key="@string/keyImeRecognitionServiceLanguage"
+        <Preference
+            android:key="@string/keyImeCombo"
             android:summary="@string/summaryImeRecognitionServiceLanguage"
-            android:title="@string/titleRecognitionServiceLanguage" />
+            android:title="@string/titleRecognitionServiceLanguage">
+            <intent
+                android:targetClass="ee.ioc.phon.android.speak.ComboSelectorActivity"
+                android:targetPackage="ee.ioc.phon.android.speak" />
+        </Preference>
     </PreferenceCategory>
 
     // Voice search activity (TODO: unify terminology: dialog, panel, UI)
@@ -63,7 +64,7 @@
             android:enabled="false"
             android:entries="@array/empty"
             android:entryValues="@array/empty"
-            android:key="@string/keyActivityRecognitionServiceLanguage"
+            android:key="@string/keyActivityCombo"
             android:summary="@string/labelRecognitionServiceHttpWithComment"
             android:title="@string/titleRecognitionServiceLanguage" />
     </PreferenceCategory>

--- a/app/res/xml/preferences.xml
+++ b/app/res/xml/preferences.xml
@@ -38,8 +38,8 @@
             android:title="@string/titleImeHelpText" />
         <Preference
             android:key="@string/keyImeCombo"
-            android:summary="@string/summaryImeRecognitionServiceLanguage"
-            android:title="@string/titleRecognitionServiceLanguage">
+            android:summary="@string/summaryImeCombo"
+            android:title="@string/titleCombo">
             <intent
                 android:targetClass="ee.ioc.phon.android.speak.ComboSelectorActivity"
                 android:targetPackage="ee.ioc.phon.android.speak" />
@@ -60,13 +60,12 @@
             android:title="@string/titleAudioCues" />
         // TODO: make the service of the main panel also user selectable
         <ListPreference
-            android:dialogTitle="@string/dialogTitleImeRecognitionServiceLanguage"
             android:enabled="false"
             android:entries="@array/empty"
             android:entryValues="@array/empty"
             android:key="@string/keyActivityCombo"
             android:summary="@string/labelRecognitionServiceHttpWithComment"
-            android:title="@string/titleRecognitionServiceLanguage" />
+            android:title="@string/titleCombo" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/titleCategoryApps">

--- a/app/src/ee/ioc/phon/android/speak/ChunkedWebRecSessionBuilder.java
+++ b/app/src/ee/ioc/phon/android/speak/ChunkedWebRecSessionBuilder.java
@@ -30,6 +30,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.speech.RecognizerIntent;
 
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
 import ee.ioc.phon.netspeechapi.recsession.ChunkedWebRecSession;
 
 /**
@@ -86,7 +87,7 @@ public class ChunkedWebRecSessionBuilder {
 		if (Log.DEBUG) Log.i(Utils.ppBundle(extras));
 
 		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		mDeviceId = Utils.getUniqueId(prefs);
+		mDeviceId = PreferenceUtils.getUniqueId(prefs);
 
 		PendingIntent pendingIntent = Utils.getPendingIntent(extras);
 

--- a/app/src/ee/ioc/phon/android/speak/ComboSelectorActivity.java
+++ b/app/src/ee/ioc/phon/android/speak/ComboSelectorActivity.java
@@ -1,0 +1,15 @@
+package ee.ioc.phon.android.speak;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class ComboSelectorActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ComboSelectorFragment details = new ComboSelectorFragment();
+        details.setArguments(getIntent().getExtras());
+        getFragmentManager().beginTransaction().add(android.R.id.content, details).commit();
+    }
+}

--- a/app/src/ee/ioc/phon/android/speak/ComboSelectorFragment.java
+++ b/app/src/ee/ioc/phon/android/speak/ComboSelectorFragment.java
@@ -1,0 +1,67 @@
+package ee.ioc.phon.android.speak;
+
+import android.app.ListFragment;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.widget.ArrayAdapter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import ee.ioc.phon.android.speak.adapter.ComboAdapter;
+import ee.ioc.phon.android.speak.model.Combo;
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
+
+public class ComboSelectorFragment extends ListFragment {
+
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+        initModel();
+    }
+
+    public void onPause() {
+        super.onPause();
+        ArrayAdapter<Combo> adapter = (ArrayAdapter<Combo>) getListAdapter();
+        Set<String> selected = new HashSet<>();
+        for (int i = 0; i < adapter.getCount(); i++) {
+            Combo combo = adapter.getItem(i);
+            if (combo.isSelected()) {
+                selected.add(combo.getId());
+            }
+        }
+        PreferenceUtils.putPrefStringSet(PreferenceManager.getDefaultSharedPreferences(getActivity()), getResources(), R.string.keyImeCombo, selected);
+    }
+
+    private void initModel() {
+        SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        Set<String> combos = PreferenceUtils.getPrefStringSet(mPrefs, getResources(), R.string.keyImeCombo);
+        RecognitionServiceManager mngr = new RecognitionServiceManager(getActivity(), combos);
+        mngr.populateCombos(getActivity(), new RecognitionServiceManager.Listener() {
+
+            @Override
+            public void onComplete(List<String> combos, List<String> combosPp, Set<String> selectedCombos) {
+                List<Combo> list = new ArrayList<Combo>();
+                for (String comboAsString : combos) {
+                    Combo combo = get(comboAsString);
+                    if (selectedCombos.contains(comboAsString)) {
+                        combo.setSelected(true);
+                    }
+                    list.add(combo);
+                }
+                Collections.sort(list, Combo.SORT_BY_LANGAUGE);
+
+                ArrayAdapter<Combo> adapter = new ComboAdapter(ComboSelectorFragment.this, list);
+                setListAdapter(adapter);
+            }
+        });
+
+    }
+
+    private Combo get(String id) {
+        return new Combo(getActivity(), id);
+    }
+}

--- a/app/src/ee/ioc/phon/android/speak/ComboSelectorFragment.java
+++ b/app/src/ee/ioc/phon/android/speak/ComboSelectorFragment.java
@@ -43,7 +43,7 @@ public class ComboSelectorFragment extends ListFragment {
         mngr.populateCombos(getActivity(), new RecognitionServiceManager.Listener() {
 
             @Override
-            public void onComplete(List<String> combos, List<String> combosPp, Set<String> selectedCombos) {
+            public void onComplete(List<String> combos, Set<String> selectedCombos) {
                 List<Combo> list = new ArrayList<Combo>();
                 for (String comboAsString : combos) {
                     Combo combo = get(comboAsString);
@@ -52,10 +52,16 @@ public class ComboSelectorFragment extends ListFragment {
                     }
                     list.add(combo);
                 }
-                Collections.sort(list, Combo.SORT_BY_LANGAUGE);
+                Collections.sort(list, Combo.SORT_BY_SELECTED_BY_LANGUAGE);
 
-                ArrayAdapter<Combo> adapter = new ComboAdapter(ComboSelectorFragment.this, list);
+                ComboAdapter adapter = new ComboAdapter(ComboSelectorFragment.this, list);
                 setListAdapter(adapter);
+
+                // TODO: the fast scroll handle overlaps with the checkboxes
+                //getListView().setFastScrollEnabled(true);
+
+                // TODO: provide more info about the number of (selected) services and languages
+                //getActivity().getActionBar().setSubtitle("" + adapter.getCount());
             }
         });
 

--- a/app/src/ee/ioc/phon/android/speak/Preferences.java
+++ b/app/src/ee/ioc/phon/android/speak/Preferences.java
@@ -26,7 +26,6 @@ import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
-import android.util.Pair;
 import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
 
@@ -35,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import ee.ioc.phon.android.speak.model.Combo;
 import ee.ioc.phon.android.speak.utils.PreferenceUtils;
 
 /**
@@ -111,14 +111,15 @@ public class Preferences extends Activity implements OnSharedPreferenceChangeLis
         return false;
     }
 
-
     private String makeSummary(Collection<String> values) {
-        List<String> pairs = new ArrayList<>();
+        List<Combo> combos = new ArrayList<>();
         for (String value : values) {
-            Pair<String, String> pair = Utils.getLabel(this, value);
-            pairs.add(String.format(getString(R.string.labelComboListItem), pair.first, pair.second));
+            combos.add(new Combo(this, value));
         }
-        Collections.sort(pairs);
-        return TextUtils.join("\n", pairs);
+        if (combos.size() == 0) {
+            return getString(R.string.emptylistCombos);
+        }
+        Collections.sort(combos, Combo.SORT_BY_LANGUAGE);
+        return TextUtils.join("\n", combos);
     }
 }

--- a/app/src/ee/ioc/phon/android/speak/Preferences.java
+++ b/app/src/ee/ioc/phon/android/speak/Preferences.java
@@ -71,7 +71,7 @@ public class Preferences extends Activity implements OnSharedPreferenceChangeLis
         super.onResume();
         mPrefs.registerOnSharedPreferenceChangeListener(this);
 
-        populateRecognitionServiceLanguageList(R.string.keyImeRecognitionServiceLanguage, R.array.defaultImeRecognizerServiceLanguage);
+        populateRecognitionServiceLanguageList(R.string.keyImeRecognitionServiceLanguage);
 
         // If the K6nele IME is enabled then we remove the link to the IME settings,
         // if not already removed.
@@ -103,18 +103,18 @@ public class Preferences extends Activity implements OnSharedPreferenceChangeLis
             List<String> pairs = new ArrayList<>();
             for (String value : mslp.getValues()) {
                 Pair<String, String> pair = Utils.getLabel(this, value);
-                pairs.add(pair.second + " @ " + pair.first);
+                pairs.add(String.format(getString(R.string.labelComboListItem), pair.first, pair.second));
             }
             Collections.sort(pairs);
             pref.setSummary(TextUtils.join("\n", pairs));
         }
     }
 
-    private void populateRecognitionServiceLanguageList(int pref, int fallbackCombos) {
+    private void populateRecognitionServiceLanguageList(int pref) {
         Set<String> combos = PreferenceUtils.getPrefStringSet(mPrefs, getResources(), pref);
         final MultiSelectListPreference mslp = (MultiSelectListPreference) mSettingsFragment.findPreference(getString(pref));
 
-        RecognitionServiceManager mngr = new RecognitionServiceManager(this, combos, fallbackCombos);
+        RecognitionServiceManager mngr = new RecognitionServiceManager(this, combos);
         mngr.populateCombos(this, new RecognitionServiceManager.Listener() {
             @Override
             public void onComplete(List<String> combos, List<String> combosPp, Set<String> selectedCombos, List<String> selectedCombosPp) {

--- a/app/src/ee/ioc/phon/android/speak/Preferences.java
+++ b/app/src/ee/ioc/phon/android/speak/Preferences.java
@@ -27,9 +27,12 @@ import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -95,8 +98,15 @@ public class Preferences extends Activity implements OnSharedPreferenceChangeLis
             pref.setSummary(lp.getEntry());
         } else if (pref instanceof MultiSelectListPreference) {
             MultiSelectListPreference mslp = (MultiSelectListPreference) pref;
-            // TODO: pretty-print
-            pref.setSummary(TextUtils.join("\n", mslp.getValues()));
+
+            // TODO: refactor
+            List<String> pairs = new ArrayList<>();
+            for (String value : mslp.getValues()) {
+                Pair<String, String> pair = Utils.getLabel(this, value);
+                pairs.add(pair.second + " @ " + pair.first);
+            }
+            Collections.sort(pairs);
+            pref.setSummary(TextUtils.join("\n", pairs));
         }
     }
 

--- a/app/src/ee/ioc/phon/android/speak/RecognitionServiceManager.java
+++ b/app/src/ee/ioc/phon/android/speak/RecognitionServiceManager.java
@@ -29,7 +29,7 @@ public class RecognitionServiceManager {
     private Set<String> mCombosExcluded = new HashSet<>();
 
     interface Listener {
-        void onComplete(List<String> combos, List<String> combosPp, Set<String> selectedCombos, List<String> selectedCombosPp);
+        void onComplete(List<String> combos, List<String> combosPp, Set<String> selectedCombos);
     }
 
     RecognitionServiceManager(Context context, Set<String> selectedCombos) {
@@ -47,19 +47,26 @@ public class RecognitionServiceManager {
         populateServices();
     }
 
+    public List<String> getServices() {
+        return mServices;
+    }
+
+    public List<String> getServicesPp() {
+        return mServicesPp;
+    }
 
     /**
      * Collect together the languages supported by the given services and call back once done.
      */
     public void populateCombos(Activity activity, final Listener listener) {
-        populateCombos(activity, 0, listener, new ArrayList<String>(), new ArrayList<String>(), new HashSet<String>(), new ArrayList<String>());
+        populateCombos(activity, 0, listener, new ArrayList<String>(), new ArrayList<String>(), new HashSet<String>());
     }
 
     private void populateCombos(final Activity activity, final int counter, final Listener listener,
-                                final List<String> combos, final List<String> combosPp, final Set<String> selectedCombos, final List<String> selectedCombosPp) {
+                                final List<String> combos, final List<String> combosPp, final Set<String> selectedCombos) {
 
         if (mServices.size() == counter) {
-            listener.onComplete(combos, combosPp, selectedCombos, selectedCombosPp);
+            listener.onComplete(combos, combosPp, selectedCombos);
             return;
         }
 
@@ -90,7 +97,7 @@ public class RecognitionServiceManager {
                     Log.i(combos.size() + ") NO LANG: " + service);
                     combos.add(service);
                     combosPp.add(mServicesPp.get(counter));
-                    populateCombos(activity, counter + 1, listener, combos, combosPp, selectedCombos, selectedCombosPp);
+                    populateCombos(activity, counter + 1, listener, combos, combosPp, selectedCombos);
                     return;
                 }
 
@@ -119,12 +126,11 @@ public class RecognitionServiceManager {
                         combosPp.add(comboPp);
                         if (mInitiallySelectedCombos.contains(combo)) {
                             selectedCombos.add(combo);
-                            selectedCombosPp.add(String.format(activity.getString(R.string.labelComboListItem), mServicesPp.get(counter), langPp));
                         }
                     }
                 }
 
-                populateCombos(activity, counter + 1, listener, combos, combosPp, selectedCombos, selectedCombosPp);
+                populateCombos(activity, counter + 1, listener, combos, combosPp, selectedCombos);
             }
         }, null, Activity.RESULT_OK, null, null);
     }

--- a/app/src/ee/ioc/phon/android/speak/RecognizerIntentActivity.java
+++ b/app/src/ee/ioc/phon/android/speak/RecognizerIntentActivity.java
@@ -68,6 +68,7 @@ import java.util.List;
 import ee.ioc.phon.android.speak.RecognizerIntentService.RecognizerBinder;
 import ee.ioc.phon.android.speak.RecognizerIntentService.State;
 import ee.ioc.phon.android.speak.provider.FileContentProvider;
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
 import ee.ioc.phon.netspeechapi.recsession.RecSessionResult;
 
 
@@ -323,7 +324,7 @@ public class RecognizerIntentActivity extends Activity {
 					if (maxRecordingTime < (SystemClock.elapsedRealtime() - mService.getStartTime())) {
 						Log.i(LOG_TAG, "Max recording time exceeded");
 						stopRecording();
-					} else if (Utils.getPrefBoolean(mPrefs, mRes, R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause) && mService.isPausing()) {
+					} else if (PreferenceUtils.getPrefBoolean(mPrefs, mRes, R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause) && mService.isPausing()) {
 						Log.i(LOG_TAG, "Speaker finished speaking");
 						stopRecording();
 					} else {
@@ -559,7 +560,7 @@ public class RecognizerIntentActivity extends Activity {
 		mLlProgress.setVisibility(View.VISIBLE);
 		mLlError.setVisibility(View.GONE);
 		setRecorderStyle(mRes.getColor(R.color.red));
-		if (Utils.getPrefBoolean(mPrefs, mRes, R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause)) {
+		if (PreferenceUtils.getPrefBoolean(mPrefs, mRes, R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause)) {
 			mBStartStop.setVisibility(View.GONE);
 			mIvVolume.setVisibility(View.VISIBLE);
 		} else {
@@ -731,7 +732,7 @@ public class RecognizerIntentActivity extends Activity {
 			pendingIntentTargetPackage = mExtraResultsPendingIntent.getTargetPackage();
 		}
 		List<String> info = new ArrayList<>();
-		info.add("ID: " + Utils.getUniqueId(PreferenceManager.getDefaultSharedPreferences(this)));
+		info.add("ID: " + PreferenceUtils.getUniqueId(PreferenceManager.getDefaultSharedPreferences(this)));
 		info.add("User-Agent comment: " + mRecSessionBuilder.getUserAgentComment());
 		info.add("Calling activity class name: " + callingActivityClassName);
 		info.add("Calling activity package name: " + callingActivityPackageName);

--- a/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
+++ b/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
@@ -1,0 +1,146 @@
+package ee.ioc.phon.android.speak;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.speech.RecognizerIntent;
+import android.speech.SpeechRecognizer;
+import android.text.SpannableString;
+import android.text.TextUtils;
+import android.view.inputmethod.EditorInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
+
+/**
+ * TODO: cleanup
+ */
+public class ServiceLanguageChooser {
+
+    private final Context mContext;
+    private final Set<String> mCombos;
+    private final List<String> mCombosAsList;
+    private final EditorInfo mAttribute;
+    private int mIndex = 0;
+    private SpeechRecognizer mSpeechRecognizer;
+    private Intent mIntent;
+
+    public ServiceLanguageChooser(Context context, SharedPreferences prefs, EditorInfo attribute) {
+
+        mContext = context;
+        mAttribute = attribute;
+        mCombos =
+                PreferenceUtils.getPrefStringSet(prefs, context.getResources(), R.string.keyImeRecognitionServiceLanguage);
+        mCombosAsList = new ArrayList<>(mCombos);
+    }
+
+    public SpeechRecognizer getSpeechRecognizer() {
+        return mSpeechRecognizer;
+    }
+
+    public Intent getIntent() {
+        return mIntent;
+    }
+
+
+    public String getLabel() {
+        String recognizer = "UNDEF";
+        String language = "UNDEF";
+        String[] splits = getCombo();
+        if (splits.length > 0) {
+            recognizer = splits[0];
+        }
+        if (splits.length > 1) {
+            language = splits[1];
+        }
+        return language + "@" + recognizer;
+    }
+
+    private String[] getCombo() {
+        String selectedCombo;
+
+        if (mCombosAsList == null && mCombosAsList.isEmpty()) {
+            selectedCombo = mContext.getResources().getString(R.string.defaultImeRecognizerServiceLanguage);
+        } else {
+            selectedCombo = mCombosAsList.get(mIndex);
+        }
+        return TextUtils.split(selectedCombo, ";");
+    }
+
+    public void next() {
+        if (++mIndex >= mCombosAsList.size()) {
+            mIndex = 0;
+        }
+
+        String language = null;
+        String[] splits = getCombo();
+
+        ComponentName recognizerComponentName = ComponentName.unflattenFromString(splits[0]);
+        if (splits.length > 1) {
+            language = splits[1];
+        }
+
+        if (recognizerComponentName == null) {
+            mSpeechRecognizer = SpeechRecognizer.createSpeechRecognizer(mContext);
+        } else {
+            mSpeechRecognizer = SpeechRecognizer.createSpeechRecognizer(mContext, recognizerComponentName);
+        }
+
+        mIntent = getRecognizerIntent(mContext, mAttribute, language);
+    }
+
+
+    private static Intent getRecognizerIntent(Context context, EditorInfo attribute, String language) {
+        // TODO: try with another action, or without an action
+        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        intent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
+        intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.getPackageName());
+        intent.putExtra(Extras.EXTRA_UNLIMITED_DURATION, true);
+        intent.putExtra(Extras.EXTRA_EDITOR_INFO, toBundle(attribute));
+        // Declaring that in the IME we would like to allow longer pauses (2 sec).
+        // The service might not implement these (e.g. Kõnele currently does not)
+        // TODO: what is the difference of these two constants?
+        intent.putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2000);
+        intent.putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 2000);
+
+        if (language != null) {
+            intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, language);
+            // TODO: make this configurable
+            intent.putExtra("android.speech.extra.EXTRA_ADDITIONAL_LANGUAGES", new String[]{});
+        }
+        return intent;
+    }
+
+
+    private static String asString(Object o) {
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof SpannableString) {
+            SpannableString ss = (SpannableString) o;
+            return ss.subSequence(0, ss.length()).toString();
+        }
+        return o.toString();
+    }
+
+
+    private static Bundle toBundle(EditorInfo attribute) {
+        Bundle bundle = new Bundle();
+        bundle.putBundle("extras", attribute.extras);
+        bundle.putString("actionLabel", asString(attribute.actionLabel));
+        bundle.putString("fieldName", asString(attribute.fieldName));
+        bundle.putString("hintText", asString(attribute.hintText));
+        bundle.putString("inputType", String.valueOf(attribute.inputType));
+        bundle.putString("label", asString(attribute.label));
+        // This line gets the actual caller package registered in the package registry.
+        // The key needs to be "packageName".
+        bundle.putString("packageName", asString(attribute.packageName));
+        return bundle;
+    }
+}

--- a/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
+++ b/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
@@ -23,62 +24,61 @@ import ee.ioc.phon.android.speak.utils.PreferenceUtils;
 public class ServiceLanguageChooser {
 
     private final Context mContext;
-    private final Set<String> mCombos;
+    private final SharedPreferences mPrefs;
     private final List<String> mCombosAsList;
     private final EditorInfo mAttribute;
-    private int mIndex = 0;
+    private int mIndex;
     private SpeechRecognizer mSpeechRecognizer;
     private Intent mIntent;
 
     public ServiceLanguageChooser(Context context, SharedPreferences prefs, EditorInfo attribute) {
 
         mContext = context;
+        mPrefs = prefs;
         mAttribute = attribute;
-        mCombos =
-                PreferenceUtils.getPrefStringSet(prefs, context.getResources(), R.string.keyImeRecognitionServiceLanguage);
-        mCombosAsList = new ArrayList<>(mCombos);
+
+        Resources res = context.getResources();
+        Set<String> mCombos = PreferenceUtils.getPrefStringSet(prefs, res, R.string.keyImeRecognitionServiceLanguage, R.array.defaultImeRecognizerServiceLanguage);
+
+        if (mCombos.isEmpty()) {
+            // If the user has chosen an empty set of combos
+            mCombosAsList = PreferenceUtils.getStringListFromStringArray(res, R.array.defaultImeRecognizerServiceLanguage);
+        } else {
+            mCombosAsList = new ArrayList<>(mCombos);
+        }
+
+        String currentCombo = PreferenceUtils.getPrefString(prefs, res, R.string.keyCurrentCombo);
+        Log.i("GET: " + currentCombo);
+        mIndex = mCombosAsList.indexOf(currentCombo);
+        // If the current combo was not found among the choices then select the first combo.
+        if (mIndex == -1) {
+            Log.i("NOT FOUND");
+            incIndex(prefs, res);
+        }
+        update();
     }
+
 
     public SpeechRecognizer getSpeechRecognizer() {
         return mSpeechRecognizer;
+    }
+
+    public int size() {
+        return mCombosAsList.size();
     }
 
     public Intent getIntent() {
         return mIntent;
     }
 
-
-    public String getLabel() {
-        String recognizer = "UNDEF";
-        String language = "UNDEF";
-        String[] splits = getCombo();
-        if (splits.length > 0) {
-            recognizer = splits[0];
-        }
-        if (splits.length > 1) {
-            language = splits[1];
-        }
-        return language + "@" + recognizer;
-    }
-
-    private String[] getCombo() {
-        String selectedCombo;
-
-        if (mCombosAsList == null && mCombosAsList.isEmpty()) {
-            selectedCombo = mContext.getResources().getString(R.string.defaultImeRecognizerServiceLanguage);
-        } else {
-            selectedCombo = mCombosAsList.get(mIndex);
-        }
-        return TextUtils.split(selectedCombo, ";");
-    }
-
     public void next() {
-        if (++mIndex >= mCombosAsList.size()) {
-            mIndex = 0;
-        }
+        incIndex(mPrefs, mContext.getResources());
+        update();
+    }
 
+    private void update() {
         String language = null;
-        String[] splits = getCombo();
+        String[] splits = TextUtils.split(getCombo(), ";");
 
         ComponentName recognizerComponentName = ComponentName.unflattenFromString(splits[0]);
         if (splits.length > 1) {
@@ -142,5 +142,22 @@ public class ServiceLanguageChooser {
         // The key needs to be "packageName".
         bundle.putString("packageName", asString(attribute.packageName));
         return bundle;
+    }
+
+
+    public String getCombo() {
+        return mCombosAsList.get(mIndex);
+    }
+
+
+    /**
+     * If called with mIndex == -1 then mIndex is set to 0
+     */
+    private void incIndex(SharedPreferences prefs, Resources res) {
+        if (++mIndex >= mCombosAsList.size()) {
+            mIndex = 0;
+        }
+        Log.i("PUT: " + mCombosAsList.get(mIndex));
+        PreferenceUtils.putPrefString(prefs, res, R.string.keyCurrentCombo, mCombosAsList.get(mIndex));
     }
 }

--- a/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
+++ b/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
@@ -38,21 +38,19 @@ public class ServiceLanguageChooser {
         mAttribute = attribute;
 
         Resources res = context.getResources();
-        Set<String> mCombos = PreferenceUtils.getPrefStringSet(prefs, res, R.string.keyImeRecognitionServiceLanguage, R.array.defaultImeRecognizerServiceLanguage);
+        Set<String> mCombos = PreferenceUtils.getPrefStringSet(prefs, res, R.string.keyImeRecognitionServiceLanguage);
 
-        if (mCombos.isEmpty()) {
+        if (mCombos == null || mCombos.isEmpty()) {
             // If the user has chosen an empty set of combos
-            mCombosAsList = PreferenceUtils.getStringListFromStringArray(res, R.array.defaultImeRecognizerServiceLanguage);
+            mCombosAsList = PreferenceUtils.getStringListFromStringArray(res, R.array.defaultImeCombos);
         } else {
             mCombosAsList = new ArrayList<>(mCombos);
         }
 
         String currentCombo = PreferenceUtils.getPrefString(prefs, res, R.string.keyCurrentCombo);
-        Log.i("GET: " + currentCombo);
         mIndex = mCombosAsList.indexOf(currentCombo);
         // If the current combo was not found among the choices then select the first combo.
         if (mIndex == -1) {
-            Log.i("NOT FOUND");
             incIndex(prefs, res);
         }
         update();
@@ -157,7 +155,6 @@ public class ServiceLanguageChooser {
         if (++mIndex >= mCombosAsList.size()) {
             mIndex = 0;
         }
-        Log.i("PUT: " + mCombosAsList.get(mIndex));
         PreferenceUtils.putPrefString(prefs, res, R.string.keyCurrentCombo, mCombosAsList.get(mIndex));
     }
 }

--- a/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
+++ b/app/src/ee/ioc/phon/android/speak/ServiceLanguageChooser.java
@@ -38,7 +38,7 @@ public class ServiceLanguageChooser {
         mAttribute = attribute;
 
         Resources res = context.getResources();
-        Set<String> mCombos = PreferenceUtils.getPrefStringSet(prefs, res, R.string.keyImeRecognitionServiceLanguage);
+        Set<String> mCombos = PreferenceUtils.getPrefStringSet(prefs, res, R.string.keyImeCombo);
 
         if (mCombos == null || mCombos.isEmpty()) {
             // If the user has chosen an empty set of combos

--- a/app/src/ee/ioc/phon/android/speak/SpeechRecognitionService.java
+++ b/app/src/ee/ioc/phon/android/speak/SpeechRecognitionService.java
@@ -21,6 +21,7 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
 import ee.ioc.phon.netspeechapi.recsession.ChunkedWebRecSession;
 import ee.ioc.phon.netspeechapi.recsession.Hypothesis;
 import ee.ioc.phon.netspeechapi.recsession.Linearization;
@@ -457,7 +458,7 @@ public class SpeechRecognitionService extends RecognitionService {
 				if (mRecorder != null) {
 					if (
 							mTimeToFinish < SystemClock.uptimeMillis() ||
-                            Utils.getPrefBoolean(mPrefs, getResources(), R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause) && mRecorder.isPausing()
+                            PreferenceUtils.getPrefBoolean(mPrefs, getResources(), R.string.keyAutoStopAfterPause, R.bool.defaultAutoStopAfterPause) && mRecorder.isPausing()
 							) {
 						stopRecording(listener);
 					} else {

--- a/app/src/ee/ioc/phon/android/speak/Utils.java
+++ b/app/src/ee/ioc/phon/android/speak/Utils.java
@@ -19,15 +19,14 @@ package ee.ioc.phon.android.speak;
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
-import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -40,6 +39,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.speech.RecognizerIntent;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
@@ -51,13 +51,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 
 
 /**
  * <p>Some useful static methods.</p>
+ *
+ * TODO: structure more, e.g. move preference utils to a separate class
  *
  * @author Kaarel Kaljurand
  */
@@ -333,18 +334,6 @@ public class Utils {
 	}
 
 
-	public static String getUniqueId(SharedPreferences settings) {
-		String id = settings.getString("id", null);
-		if (id == null) {
-			id = UUID.randomUUID().toString();
-			SharedPreferences.Editor editor = settings.edit();
-			editor.putString("id", id);
-			editor.apply();
-		}
-		return id;
-	}
-
-
 	public static List<String> ppBundle(Bundle bundle) {
 		return ppBundle("/", bundle);
 	}
@@ -409,19 +398,6 @@ public class Utils {
 	}
 
 
-	public static String getPrefString(SharedPreferences prefs, Resources res, int key, int defaultValue) {
-		return prefs.getString(res.getString(key), res.getString(defaultValue));
-	}
-
-	public static String getPrefString(SharedPreferences prefs, Resources res, int key) {
-		return prefs.getString(res.getString(key), null);
-	}
-
-	public static boolean getPrefBoolean(SharedPreferences prefs, Resources res, int key, int defaultValue) {
-		return prefs.getBoolean(res.getString(key), res.getBoolean(defaultValue));
-	}
-
-
 	private static boolean isActivityAvailable(Context context, Intent intent) {
 		final PackageManager mgr = context.getPackageManager();
 		List<ResolveInfo> list = mgr.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
@@ -454,5 +430,14 @@ public class Utils {
 			return Locale.forLanguageTag(localeAsStr).getDisplayName();
 		}
 		return localeAsStr;
+	}
+
+	/**
+	 * @param str string like {@code ee.ioc.phon.android.speak/.WebSocketRecognizer;et-ee}
+	 * @return ComponentName in the input string
+	 */
+	public static ComponentName getComponentName(String str) {
+		String[] splits = TextUtils.split(str, ";");
+		return ComponentName.unflattenFromString(splits[0]);
 	}
 }

--- a/app/src/ee/ioc/phon/android/speak/Utils.java
+++ b/app/src/ee/ioc/phon/android/speak/Utils.java
@@ -450,11 +450,13 @@ public class Utils {
 		if (splits.length > 0) {
 			PackageManager pm = context.getPackageManager();
 			ComponentName recognizerComponentName = ComponentName.unflattenFromString(splits[0]);
-			try {
-				ServiceInfo si = pm.getServiceInfo(recognizerComponentName, 0);
-				recognizer = si.loadLabel(pm).toString();
-			} catch (PackageManager.NameNotFoundException e) {
-				// ignored
+			if (recognizerComponentName != null) {
+				try {
+					ServiceInfo si = pm.getServiceInfo(recognizerComponentName, 0);
+					recognizer = si.loadLabel(pm).toString();
+				} catch (PackageManager.NameNotFoundException e) {
+					// ignored
+				}
 			}
 		}
 		if (splits.length > 1) {

--- a/app/src/ee/ioc/phon/android/speak/Utils.java
+++ b/app/src/ee/ioc/phon/android/speak/Utils.java
@@ -27,6 +27,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
+import android.content.pm.ServiceInfo;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -40,9 +41,12 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.speech.RecognizerIntent;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
+
+import org.apache.commons.io.FileUtils;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -51,8 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-
-import org.apache.commons.io.FileUtils;
 
 
 /**
@@ -439,5 +441,25 @@ public class Utils {
 	public static ComponentName getComponentName(String str) {
 		String[] splits = TextUtils.split(str, ";");
 		return ComponentName.unflattenFromString(splits[0]);
+	}
+
+	public static Pair<String, String> getLabel(Context context, String comboAsString) {
+		String recognizer = "???";
+		String language = "???";
+		String[] splits = TextUtils.split(comboAsString, ";");
+		if (splits.length > 0) {
+			PackageManager pm = context.getPackageManager();
+			ComponentName recognizerComponentName = ComponentName.unflattenFromString(splits[0]);
+			try {
+				ServiceInfo si = pm.getServiceInfo(recognizerComponentName, 0);
+				recognizer = si.loadLabel(pm).toString();
+			} catch (PackageManager.NameNotFoundException e) {
+				// ignored
+			}
+		}
+		if (splits.length > 1) {
+			language = Utils.makeLangLabel(splits[1]);
+		}
+		return new Pair<>(recognizer, language);
 	}
 }

--- a/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
+++ b/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
@@ -61,7 +61,7 @@ public class VoiceImeView extends LinearLayout {
         mBImeStartStop = (MicButton) findViewById(R.id.bImeStartStop);
         mBImeKeyboard = (ImageButton) findViewById(R.id.bImeKeyboard);
         mBImeGo = (ImageButton) findViewById(R.id.bImeGo);
-        mBComboSelector = (Button) findViewById(R.id.tvServiceLanguage);
+        mBComboSelector = (Button) findViewById(R.id.tvComboSelector);
         mTvInstruction = (TextView) findViewById(R.id.tvInstruction);
         mTvMessage = (TextView) findViewById(R.id.tvMessage);
 

--- a/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
+++ b/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
@@ -1,7 +1,6 @@
 package ee.ioc.phon.android.speak;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -11,6 +10,7 @@ import android.util.AttributeSet;
 import android.util.Pair;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -40,7 +40,7 @@ public class VoiceImeView extends LinearLayout {
     private MicButton mBImeStartStop;
     private ImageButton mBImeKeyboard;
     private ImageButton mBImeGo;
-    private TextView mTvServiceLanguage;
+    private Button mBComboSelector;
     private TextView mTvInstruction;
     private TextView mTvMessage;
 
@@ -60,7 +60,7 @@ public class VoiceImeView extends LinearLayout {
         mBImeStartStop = (MicButton) findViewById(R.id.bImeStartStop);
         mBImeKeyboard = (ImageButton) findViewById(R.id.bImeKeyboard);
         mBImeGo = (ImageButton) findViewById(R.id.bImeGo);
-        mTvServiceLanguage = (TextView) findViewById(R.id.tvServiceLanguage);
+        mBComboSelector = (Button) findViewById(R.id.tvServiceLanguage);
         mTvInstruction = (TextView) findViewById(R.id.tvInstruction);
         mTvMessage = (TextView) findViewById(R.id.tvMessage);
 
@@ -109,9 +109,10 @@ public class VoiceImeView extends LinearLayout {
             }
         });
 
-        mTvServiceLanguage.setOnClickListener(new OnClickListener() {
+        mBComboSelector.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                mSlc.next();
                 updateServiceLanguage(mSlc);
             }
         });
@@ -389,8 +390,13 @@ public class VoiceImeView extends LinearLayout {
     private void updateServiceLanguage(ServiceLanguageChooser slc) {
         // Cancel a possibly running service and start a new one
         closeSession();
-        slc.next();
-        mTvServiceLanguage.setText(slc.getLabel());
+        if (slc.size() > 1) {
+            mBComboSelector.setVisibility(View.VISIBLE);
+            Pair<String, String> pair = Utils.getLabel(getContext(), slc.getCombo());
+            mBComboSelector.setText(pair.second + " @ " + pair.first);
+        } else {
+            mBComboSelector.setVisibility(View.GONE);
+        }
         mRecognizer = slc.getSpeechRecognizer();
         mRecognizer.setRecognitionListener(getRecognizerListener());
     }

--- a/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
+++ b/app/src/ee/ioc/phon/android/speak/VoiceImeView.java
@@ -1,6 +1,7 @@
 package ee.ioc.phon.android.speak;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -121,6 +122,17 @@ public class VoiceImeView extends LinearLayout {
             public void onClick(View v) {
                 mSlc.next();
                 updateServiceLanguage(mSlc);
+            }
+        });
+
+        mBComboSelector.setOnLongClickListener(new OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                Context context = getContext();
+                Intent intent = new Intent(context, ComboSelectorActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                Utils.startActivityIfAvailable(context, intent);
+                return true;
             }
         });
 

--- a/app/src/ee/ioc/phon/android/speak/WebSocketRecognizer.java
+++ b/app/src/ee/ioc/phon/android/speak/WebSocketRecognizer.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import ee.ioc.phon.android.speak.utils.PreferenceUtils;
+
 public class WebSocketRecognizer extends RecognitionService {
 
     private static final String PROTOCOL = "";
@@ -325,7 +327,7 @@ public class WebSocketRecognizer extends RecognitionService {
     private String getWsServiceUrl(Intent intent) {
         String url = intent.getStringExtra(Extras.EXTRA_SERVER_URL);
         if (url == null) {
-            return Utils.getPrefString(
+            return PreferenceUtils.getPrefString(
                     PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext()),
                     getResources(),
                     R.string.keyServerWs,

--- a/app/src/ee/ioc/phon/android/speak/adapter/ComboAdapter.java
+++ b/app/src/ee/ioc/phon/android/speak/adapter/ComboAdapter.java
@@ -34,7 +34,7 @@ public class ComboAdapter extends ArrayAdapter<Combo> {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        View view = null;
+        View view;
         if (convertView == null) {
             LayoutInflater inflator = context.getLayoutInflater();
             view = inflator.inflate(R.layout.list_item_combo, null);

--- a/app/src/ee/ioc/phon/android/speak/adapter/ComboAdapter.java
+++ b/app/src/ee/ioc/phon/android/speak/adapter/ComboAdapter.java
@@ -1,0 +1,69 @@
+package ee.ioc.phon.android.speak.adapter;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.TextView;
+
+import java.util.List;
+
+import ee.ioc.phon.android.speak.R;
+import ee.ioc.phon.android.speak.model.Combo;
+
+public class ComboAdapter extends ArrayAdapter<Combo> {
+
+    private final List<Combo> list;
+    private final Activity context;
+
+    public ComboAdapter(Fragment context, List<Combo> list) {
+        super(context.getActivity(), R.layout.list_item_combo, list);
+        this.context = context.getActivity();
+        this.list = list;
+    }
+
+    static class ViewHolder {
+        protected TextView language;
+        protected TextView service;
+        protected CheckBox checkbox;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        View view = null;
+        if (convertView == null) {
+            LayoutInflater inflator = context.getLayoutInflater();
+            view = inflator.inflate(R.layout.list_item_combo, null);
+            final ViewHolder viewHolder = new ViewHolder();
+            viewHolder.language = (TextView) view.findViewById(R.id.language);
+            viewHolder.service = (TextView) view.findViewById(R.id.service);
+            viewHolder.checkbox = (CheckBox) view.findViewById(R.id.check);
+            viewHolder.checkbox
+                    .setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+
+                        @Override
+                        public void onCheckedChanged(CompoundButton buttonView,
+                                                     boolean isChecked) {
+                            Combo element = (Combo) viewHolder.checkbox
+                                    .getTag();
+                            element.setSelected(buttonView.isChecked());
+
+                        }
+                    });
+            view.setTag(viewHolder);
+            viewHolder.checkbox.setTag(list.get(position));
+        } else {
+            view = convertView;
+            ((ViewHolder) view.getTag()).checkbox.setTag(list.get(position));
+        }
+        ViewHolder holder = (ViewHolder) view.getTag();
+        holder.language.setText(list.get(position).getLanguage());
+        holder.service.setText(list.get(position).getService());
+        holder.checkbox.setChecked(list.get(position).isSelected());
+        return view;
+    }
+}

--- a/app/src/ee/ioc/phon/android/speak/model/Combo.java
+++ b/app/src/ee/ioc/phon/android/speak/model/Combo.java
@@ -1,0 +1,61 @@
+package ee.ioc.phon.android.speak.model;
+
+import android.content.Context;
+import android.util.Pair;
+
+import java.util.Comparator;
+
+import ee.ioc.phon.android.speak.R;
+import ee.ioc.phon.android.speak.Utils;
+
+public class Combo {
+
+    public static final SortByLangauge SORT_BY_LANGAUGE = new SortByLangauge();
+
+    private final String mId;
+    private final String mService;
+    private final String mLanguage;
+    private final Context mContext;
+    private boolean mIsSelected;
+
+    public Combo(Context context, String id) {
+        mContext = context;
+        mId = id;
+        Pair<String, String> comboPair = Utils.getLabel(context, id);
+        mService = comboPair.first;
+        mLanguage = comboPair.second;
+    }
+
+    public String getId() {
+        return mId;
+    }
+
+    public String getService() {
+        return mService;
+    }
+
+    public String getLanguage() {
+        return mLanguage;
+    }
+
+    public String getName() {
+        return String.format(mContext.getString(R.string.labelComboListItem), mService, mLanguage);
+    }
+
+    public boolean isSelected() {
+        return mIsSelected;
+    }
+
+    public void setSelected(boolean b) {
+        mIsSelected = b;
+    }
+
+    private static class SortByLangauge implements Comparator {
+
+        public int compare(Object o1, Object o2) {
+            Combo c1 = (Combo) o1;
+            Combo c2 = (Combo) o2;
+            return c1.getLanguage().compareToIgnoreCase(c2.getLanguage());
+        }
+    }
+}

--- a/app/src/ee/ioc/phon/android/speak/model/Combo.java
+++ b/app/src/ee/ioc/phon/android/speak/model/Combo.java
@@ -10,7 +10,8 @@ import ee.ioc.phon.android.speak.Utils;
 
 public class Combo {
 
-    public static final SortByLangauge SORT_BY_LANGAUGE = new SortByLangauge();
+    public static final Comparator SORT_BY_LANGUAGE = new SortByLanguage();
+    public static final Comparator SORT_BY_SELECTED_BY_LANGUAGE = new SortBySelectedByLanguage();
 
     private final String mId;
     private final String mService;
@@ -38,7 +39,7 @@ public class Combo {
         return mLanguage;
     }
 
-    public String getName() {
+    public String toString() {
         return String.format(mContext.getString(R.string.labelComboListItem), mService, mLanguage);
     }
 
@@ -50,12 +51,25 @@ public class Combo {
         mIsSelected = b;
     }
 
-    private static class SortByLangauge implements Comparator {
+    private static class SortByLanguage implements Comparator {
 
         public int compare(Object o1, Object o2) {
             Combo c1 = (Combo) o1;
             Combo c2 = (Combo) o2;
             return c1.getLanguage().compareToIgnoreCase(c2.getLanguage());
+        }
+    }
+
+    private static class SortBySelectedByLanguage implements Comparator {
+
+        public int compare(Object o1, Object o2) {
+            Combo c1 = (Combo) o1;
+            Combo c2 = (Combo) o2;
+            if (c1.isSelected() && c2.isSelected() || !c1.isSelected() && !c2.isSelected()) {
+                return c1.getLanguage().compareToIgnoreCase(c2.getLanguage());
+            }
+            if (c1.isSelected()) return -1;
+            return 1;
         }
     }
 }

--- a/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
+++ b/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
@@ -56,4 +56,10 @@ public class PreferenceUtils {
         editor.putString(res.getString(key), value);
         editor.apply();
     }
+
+    public static void putPrefStringSet(SharedPreferences prefs, Resources res, int key, Set<String> value) {
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putStringSet(res.getString(key), value);
+        editor.apply();
+    }
 }

--- a/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
+++ b/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -44,5 +45,15 @@ public class PreferenceUtils {
 
     public static Set<String> getStringSetFromStringArray(Resources res, int key) {
         return new HashSet<>(Arrays.asList(res.getStringArray(key)));
+    }
+
+    public static List<String> getStringListFromStringArray(Resources res, int key) {
+        return Arrays.asList(res.getStringArray(key));
+    }
+
+    public static void putPrefString(SharedPreferences prefs, Resources res, int key, String value) {
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(res.getString(key), value);
+        editor.apply();
     }
 }

--- a/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
+++ b/app/src/ee/ioc/phon/android/speak/utils/PreferenceUtils.java
@@ -1,0 +1,48 @@
+package ee.ioc.phon.android.speak.utils;
+
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class PreferenceUtils {
+
+    public static String getPrefString(SharedPreferences prefs, Resources res, int key, int defaultValue) {
+        return prefs.getString(res.getString(key), res.getString(defaultValue));
+    }
+
+    public static String getPrefString(SharedPreferences prefs, Resources res, int key) {
+        return prefs.getString(res.getString(key), null);
+    }
+
+    public static Set<String> getPrefStringSet(SharedPreferences prefs, Resources res, int key) {
+        return prefs.getStringSet(res.getString(key), Collections.<String>emptySet());
+    }
+
+    public static Set<String> getPrefStringSet(SharedPreferences prefs, Resources res, int key, int defaultValue) {
+        return prefs.getStringSet(res.getString(key), getStringSetFromStringArray(res, defaultValue));
+    }
+
+    public static boolean getPrefBoolean(SharedPreferences prefs, Resources res, int key, int defaultValue) {
+        return prefs.getBoolean(res.getString(key), res.getBoolean(defaultValue));
+    }
+
+    public static String getUniqueId(SharedPreferences settings) {
+        String id = settings.getString("id", null);
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+            SharedPreferences.Editor editor = settings.edit();
+            editor.putString("id", id);
+            editor.apply();
+        }
+        return id;
+    }
+
+    public static Set<String> getStringSetFromStringArray(Resources res, int key) {
+        return new HashSet<>(Arrays.asList(res.getStringArray(key)));
+    }
+}


### PR DESCRIPTION
Speech keyboard settings: merges the separate services and languages settings into one setting, removes "system default" and allows multiple service-language combos to be selected.

Speech keyboard itself: new button (visible if multiple service-language combos have been selected) to rotate through the selected combos.

