### PR TITLE
Add Compose-based combo manager skeleton

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':speechutils:app')
@@ -13,6 +14,15 @@ dependencies {
     // implementation 'androidx.activity:activity:1.4.0'
     implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
     implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation 'androidx.compose.ui:ui:1.5.4'
+    implementation 'androidx.compose.material3:material3:1.1.2'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.5.4'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.5.4'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'androidx.room:room-ktx:2.6.1'
+    implementation 'androidx.room:room-runtime:2.6.1'
+    kapt 'androidx.room:room-compiler:2.6.1'
 }
 
 android {
@@ -66,6 +76,10 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.4'
     }
     lint {
         // TODO: in the future check for Kotlin-Java interop

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -287,6 +287,11 @@ Also, failed to set the launchMode from the resource, INSTALL_PARSE_FAILED_UNEXP
             android:label="@string/dialogTitleCombo"
             android:parentActivityName=".activity.Preferences" />
         <activity
+            android:name=".activity.ComboListActivity"
+            android:exported="false"
+            android:label="@string/dialogTitleCombo"
+            android:parentActivityName=".activity.Preferences" />
+        <activity
             android:name=".activity.RecServiceSelectorActivity"
             android:exported="true"
             android:label="@string/titleServices"

--- a/app/src/main/java/ee/ioc/phon/android/speak/activity/ComboListActivity.kt
+++ b/app/src/main/java/ee/ioc/phon/android/speak/activity/ComboListActivity.kt
@@ -1,0 +1,39 @@
+package ee.ioc.phon.android.speak.activity
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import ee.ioc.phon.android.speak.db.AppDatabase
+import ee.ioc.phon.android.speak.db.ComboEntity
+
+class ComboListActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val dao = AppDatabase.getDatabase(this).comboDao()
+        setContent {
+            val combos by dao.getAll().collectAsState(initial = emptyList())
+            ComboListScreen(combos)
+        }
+    }
+}
+
+@Composable
+fun ComboListScreen(combos: List<ComboEntity>) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        LazyColumn {
+            items(combos, key = { it.id }) { combo ->
+                Text(text = combo.longLabel)
+            }
+        }
+    }
+}

--- a/app/src/main/java/ee/ioc/phon/android/speak/db/AppDatabase.kt
+++ b/app/src/main/java/ee/ioc/phon/android/speak/db/AppDatabase.kt
@@ -1,0 +1,28 @@
+package ee.ioc.phon.android.speak.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [ComboEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun comboDao(): ComboDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getDatabase(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "combos.db"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/ee/ioc/phon/android/speak/db/ComboDao.kt
+++ b/app/src/main/java/ee/ioc/phon/android/speak/db/ComboDao.kt
@@ -1,0 +1,23 @@
+package ee.ioc.phon.android.speak.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ComboDao {
+    @Query("SELECT * FROM combos ORDER BY position")
+    fun getAll(): Flow<List<ComboEntity>>
+
+    @Insert
+    suspend fun insert(combo: ComboEntity)
+
+    @Update
+    suspend fun update(combo: ComboEntity)
+
+    @Delete
+    suspend fun delete(combo: ComboEntity)
+}

--- a/app/src/main/java/ee/ioc/phon/android/speak/db/ComboEntity.kt
+++ b/app/src/main/java/ee/ioc/phon/android/speak/db/ComboEntity.kt
@@ -1,0 +1,14 @@
+package ee.ioc.phon.android.speak.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "combos")
+data class ComboEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val comboId: String,
+    val shortLabel: String,
+    val longLabel: String,
+    val enabled: Boolean = true,
+    val position: Int = 0
+)


### PR DESCRIPTION
## Summary
- set up Compose and Room dependencies
- create simple `AppDatabase` with `Combo` entity/DAO
- implement new `ComboListActivity` using Jetpack Compose
- register the activity in the manifest

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476a34d6648324ba8c645b35f9a950